### PR TITLE
Removed erroneous comma from rotate and translate classes

### DIFF
--- a/Stream-1/Unit05-gradients_transforms_&-_transitions/transitions/transitions.html
+++ b/Stream-1/Unit05-gradients_transforms_&-_transitions/transitions/transitions.html
@@ -24,13 +24,13 @@
 		.rotateMe:hover{
         transform:perspective(800px) rotateY(70deg);/*uses 3D animation to rotate element */
        	background-color: red;/*colour changes to red on hover*/
-		transition: 1s, ease-in-out,;/*transition begins after 1 second*/
+		transition: 1s, ease-in-out;/*transition begins after 1 second*/
 		
 		}
 		.translateMe:hover{
 		transform:translate(200px,100px);/*movess element on hover*/
 		background-color: red;
-		transition: 1s, ease-in-out,;
+		transition: 1s, ease-in-out;
 	
 
 		}


### PR DESCRIPTION
One of my students was having issues getting this section to work, investigated and discovered there was an extra comma on 2 of the classes.  This PR fixes that.
